### PR TITLE
Update RETURN_TYPES to include video URL in multiple generators

### DIFF
--- a/generators/i2v.py
+++ b/generators/i2v.py
@@ -94,7 +94,8 @@ class WanI2VGenerator(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan"
     
@@ -151,7 +152,7 @@ class WanI2VGenerator(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -245,9 +246,11 @@ class WanI2VGenerator(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "videos/" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "videos/" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/generators/ii2v.py
+++ b/generators/ii2v.py
@@ -94,7 +94,8 @@ class WanII2VGenerator(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan"
     
@@ -152,7 +153,7 @@ class WanII2VGenerator(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -246,9 +247,11 @@ class WanII2VGenerator(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "videos/" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "videos/" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/generators/t2i.py
+++ b/generators/t2i.py
@@ -81,7 +81,8 @@ class WanT2IGenerator(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("IMAGE",)
+    RETURN_TYPES = ("IMAGE", "STRING")  # Returns image tensor and image URL
+    RETURN_NAMES = ("image", "image_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan"
     
@@ -222,7 +223,8 @@ class WanT2IGenerator(WanAPIBase):
                         image_tensor = torch.from_numpy(np.array(image).astype(np.float32) / 255.0)
                         image_tensor = image_tensor.unsqueeze(0)  # Add batch dimension
                         
-                        return (image_tensor,)
+                        # Return both the image tensor and the image URL
+                        return (image_tensor, image_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/generators/t2v.py
+++ b/generators/t2v.py
@@ -89,7 +89,8 @@ class WanT2VGenerator(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan"
     
@@ -165,7 +166,7 @@ class WanT2VGenerator(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -259,9 +260,11 @@ class WanT2VGenerator(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "videos/" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "videos/" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/vace/image_reference.py
+++ b/vace/image_reference.py
@@ -102,7 +102,8 @@ class WanVACEImageReference(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan/VACE"
     
@@ -188,7 +189,7 @@ class WanVACEImageReference(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -282,9 +283,11 @@ class WanVACEImageReference(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/vace/video_edit.py
+++ b/vace/video_edit.py
@@ -151,7 +151,8 @@ class WanVACEVideoEdit(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan/VACE"
     
@@ -239,7 +240,7 @@ class WanVACEVideoEdit(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -333,9 +334,11 @@ class WanVACEVideoEdit(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/vace/video_extension.py
+++ b/vace/video_extension.py
@@ -112,7 +112,8 @@ class WanVACEVideoExtension(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan/VACE"
     
@@ -193,7 +194,7 @@ class WanVACEVideoExtension(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -287,9 +288,11 @@ class WanVACEVideoExtension(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/vace/video_outpainting.py
+++ b/vace/video_outpainting.py
@@ -108,7 +108,8 @@ class WanVACEVideoOutpainting(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan/VACE"
     
@@ -176,7 +177,7 @@ class WanVACEVideoOutpainting(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -270,9 +271,11 @@ class WanVACEVideoOutpainting(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         

--- a/vace/video_repainting.py
+++ b/vace/video_repainting.py
@@ -106,7 +106,8 @@ class WanVACEVideoRepainting(WanAPIBase):
             }
         }
     
-    RETURN_TYPES = ("STRING",)  # Returns path to downloaded video file
+    RETURN_TYPES = ("STRING", "STRING")  # Returns path to downloaded video file and video URL
+    RETURN_NAMES = ("video_file_path", "video_url")
     FUNCTION = "generate"
     CATEGORY = "Ru4ls/Wan/VACE"
     
@@ -174,7 +175,7 @@ class WanVACEVideoRepainting(WanAPIBase):
                 
                 # Now we need to poll for the result
                 task_result = self.poll_task_result(task_id, output_dir)
-                return (task_result,)  # Return path to downloaded video file
+                return task_result  # Return both path to downloaded video file and video URL
             else:
                 raise ValueError(f"Unexpected API response format: {result}")
                 
@@ -268,9 +269,11 @@ class WanVACEVideoRepainting(WanAPIBase):
                         print(f"Video downloaded and saved to: {video_path}")
                         # Return path relative to ComfyUI output directory if using ComfyUI
                         if COMFYUI_AVAILABLE and not output_dir.startswith(("./", "/")):
-                            return os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
+                            return_path = os.path.join(output_dir, video_filename) if output_dir != "./videos" else video_filename
                         else:
-                            return video_path  # Return full path
+                            return_path = video_path  # Return full path
+                        # Return both the file path and the video URL
+                        return (return_path, video_url)
                     else:
                         raise ValueError(f"Unexpected API response format: {result}")
                         


### PR DESCRIPTION
Enhance multiple generators to return both the path to the downloaded image or video file and the corresponding image or video URL. This update improves the functionality and usability of the generators.