### PR TITLE
chore: updated the README.md file to reflect the changes in RETURN_TYPES for all nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a direct integration with Alibaba Cloud's Model Studio service, not a th
 - **Commercial Licensing**: Properly licensed for commercial use through Alibaba Cloud's terms of service
 - **Scalable Architecture**: Handles high-volume workloads with Alibaba Cloud's reliable infrastructure
 - **Security Compliance**: Follows Alibaba Cloud's security best practices with secure API key management
+- **Enhanced Output Options**: All video generation nodes now return both local file paths and remote URLs for flexible workflow integration
 
 ## Important: API Costs & Authorization
 
@@ -57,15 +58,15 @@ All API endpoints are centrally managed in the `core/base.py` file, making it ea
 
 | Node Name | Function | Model | Description |
 |-----------|----------|-------|-------------|
-| Wan Text-to-Image Generator | T2I | wan2.2-t2i-flash, wan2.2-t2i-plus | Generate images from text prompts with multiple resolution options |
-| Wan Image-to-Video Generator | I2V | wan2.2-i2v-flash, wan2.2-i2v-plus | Create 5-second videos from a single image and text prompt |
-| Wan Text-to-Video Generator | T2V | wan2.2-t2v-plus | Generate 5-second videos directly from text prompts |
-| Wan Image-to-Video (First/Last Frame) Generator | II2V | wan2.1-kf2v-plus | Create 5-second videos using both first and last frame images |
-| Wan VACE - Multi-Image Reference | VACE | wan2.1-vace-plus | Generate videos from multiple reference images |
-| Wan VACE - Video Repainting | VACE | wan2.1-vace-plus | Repaint videos while preserving motion |
-| Wan VACE - Local Video Editing | VACE | wan2.1-vace-plus | Locally edit specific areas of videos |
-| Wan VACE - Video Extension | VACE | wan2.1-vace-plus | Extend videos with additional content |
-| Wan VACE - Video Outpainting | VACE | wan2.1-vace-plus | Scale videos in different directions |
+| Wan Text-to-Image Generator | T2I | wan2.2-t2i-flash, wan2.2-t2i-plus | Generate images from text prompts with multiple resolution options. Returns both image tensor and image URL. |
+| Wan Image-to-Video Generator | I2V | wan2.2-i2v-flash, wan2.2-i2v-plus | Create 5-second videos from a single image and text prompt. Returns both video file path and video URL. |
+| Wan Text-to-Video Generator | T2V | wan2.2-t2v-plus | Generate 5-second videos directly from text prompts. Returns both video file path and video URL. |
+| Wan Image-to-Video (First/Last Frame) Generator | II2V | wan2.1-kf2v-plus | Create 5-second videos using both first and last frame images. Returns both video file path and video URL. |
+| Wan VACE - Multi-Image Reference | VACE | wan2.1-vace-plus | Generate videos from multiple reference images. Returns both video file path and video URL. |
+| Wan VACE - Video Repainting | VACE | wan2.1-vace-plus | Repaint videos while preserving motion. Returns both video file path and video URL. |
+| Wan VACE - Local Video Editing | VACE | wan2.1-vace-plus | Locally edit specific areas of videos. Returns both video file path and video URL. |
+| Wan VACE - Video Extension | VACE | wan2.1-vace-plus | Extend videos with additional content. Returns both video file path and video URL. |
+| Wan VACE - Video Outpainting | VACE | wan2.1-vace-plus | Scale videos in different directions. Returns both video file path and video URL. |
 
 ## Features
 
@@ -73,6 +74,7 @@ All API endpoints are centrally managed in the `core/base.py` file, making it ea
 - **Configurable Parameters**: Seed, resolution, prompt extension, watermark, negative prompts, and more
 - **Specialized VACE Nodes**: The Universal Video Editing (VACE) model has been split into 5 specialized nodes for better usability and focused functionality
 - **Powered by Alibaba Cloud's Advanced Wan Models**: Access to state-of-the-art models with continuous updates
+- **Dual Output Support**: All video generation nodes now return both local file paths and remote URLs for flexible workflow integration
 
 ## Installation
 
@@ -129,8 +131,9 @@ DASHSCOPE_API_KEY=your_actual_api_key_here
 4. Connect a text input with your prompt describing the video content
 5. Optionally configure the output directory where the video will be saved (can be browsed in ComfyUI)
 6. Execute the node
-7. The node will return a path to the downloaded video file
+7. The node will return both a path to the downloaded video file and the video URL
 8. To preview the video, connect the output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+9. To use the video URL directly (e.g., for sharing or further processing), you can connect the video_url output to appropriate nodes
 
 **Note**: The image URL must be publicly accessible (not behind authentication or on localhost). 
 You can use services like Imgur, cloud storage providers, or your own web server to host the image.
@@ -146,6 +149,10 @@ You can use services like Imgur, cloud storage providers, or your own web server
 - **seed**: Random seed for generation (0 for random)
 - **watermark**: Add Wan watermark to output
 
+**Return Values:**
+- **image**: Generated image as a tensor (can be connected directly to other ComfyUI nodes)
+- **image_url**: URL of the generated image on Alibaba Cloud's servers
+
 ### Text-to-Video Generator
 - **model**: Select the Wan model to use (wan2.2-t2v-plus)
 - **prompt** (required): The text prompt for video generation
@@ -155,6 +162,10 @@ You can use services like Imgur, cloud storage providers, or your own web server
 - **seed**: Random seed for generation (0 for random)
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
+
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
 
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
@@ -169,6 +180,10 @@ You can use services like Imgur, cloud storage providers, or your own web server
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
 
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
+
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
 ### Image-to-Video (First/Last Frame) Generator
@@ -182,6 +197,10 @@ You can use services like Imgur, cloud storage providers, or your own web server
 - **seed**: Random seed for generation (0 for random)
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
+
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
 
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
@@ -206,6 +225,10 @@ The node intelligently handles the obj_or_bg parameter:
 - For a single reference image: Automatically set to ["obj"]
 - For multiple reference images: Automatically set to ["obj", "obj", ..., "bg"] where the last image is treated as background
 
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
+
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
 ### Wan VACE - Video Repainting
@@ -222,6 +245,10 @@ This node repaints videos while preserving motion using the Wan VACE model.
 - **prompt_extend**: Enable intelligent prompt rewriting for better results
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
+
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
 
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
@@ -246,6 +273,10 @@ This node locally edits specific areas of videos using the Wan VACE model.
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
 
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
+
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
 ### Wan VACE - Video Extension
@@ -265,6 +296,10 @@ This node extends videos with additional content using the Wan VACE model.
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
 
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
+
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
 ### Wan VACE - Video Outpainting
@@ -283,6 +318,10 @@ This node scales videos in different directions using the Wan VACE model.
 - **watermark**: Add Wan watermark to output
 - **output_dir**: Directory where the generated video will be saved. Can be browsed and selected in ComfyUI.
 
+**Return Values:**
+- **video_file_path**: Path to the downloaded video file on your local system
+- **video_url**: URL of the generated video on Alibaba Cloud's servers
+
 **Note**: To preview the generated video in ComfyUI, connect the output of this node to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite.
 
 ## Examples
@@ -298,8 +337,9 @@ Prompt: "Generate an image of a cat swimming under the water"
 3. Connect a text input with your prompt (e.g., "A kitten running in the moonlight")
 4. Optionally configure the output directory where the video will be saved (can be browsed in ComfyUI)
 5. Execute the node
-6. The node will return a path to the downloaded video file
-7. To preview the video, connect the output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+6. The node will return both a path to the downloaded video file and the video URL
+7. To preview the video, connect the video_file_path output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+8. To use the video URL directly (e.g., for sharing or further processing), you can connect the video_url output to appropriate nodes
 
 ![Text-to-Video Example](media/ComfyUI_Wan-t2v.png)
 
@@ -307,7 +347,8 @@ Prompt: "Generate an image of a cat swimming under the water"
 1. First frame: Provide a URL to an image (e.g., "https://example.com/your_image.png")
 2. Prompt: "a cat running in the grass"
 3. Output directory: "./videos" (default) or any custom path
-4. To preview: Connect the output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+4. To preview: Connect the video_file_path output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+5. To share or process further: Use the video_url output directly in your workflow
 
 ![Image-to-Video Example](media/ComfyUI_Wan-i2v-new.png)
 
@@ -318,8 +359,9 @@ Prompt: "Generate an image of a cat swimming under the water"
 4. Prompt: "a cat running in the grass"Realistic style. A black kitten looks up at the sky curiously. The camera gradually rises from eye level, ending with a top-down shot of the kitten's curious eyes."
 5. Optionally configure the output directory where the video will be saved (can be browsed in ComfyUI)
 6. Execute the node
-7. The node will return a path to the downloaded video file
-8. To preview the video, connect the output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+7. The node will return both a path to the downloaded video file and the video URL
+8. To preview the video, connect the video_file_path output to a "Load Video (Path)" node from ComfyUI-VideoHelperSuite
+9. To use the video URL directly (e.g., for sharing or further processing), you can connect the video_url output to appropriate nodes
 
 ![Image-first-last-frame-to-Video Example](media/ComfyUI_Wan-ii2v.png)
 


### PR DESCRIPTION
1. Updated the Available Nodes section to mention that video generation nodes return both file paths and URLs, and image generation nodes return both image tensors and URLs.

2. Updated the Node Parameters section for all nodes to include a "Return Values" subsection that clearly explains what each node outputs:
      - Text-to-Image nodes return both an image tensor and image URL
      - All video generation nodes return both a video file path and video URL

3. Updated the Features section to highlight the dual output support as a key feature.

4. Updated the Usage section to explain how to use both outputs from the nodes.

5. Updated all Examples sections to show how to use both the file path and URL outputs.