### PR TITLE
Add WanI2VEffectGenerator to backward compatibility module

### DIFF
--- a/wan_nodes.py
+++ b/wan_nodes.py
@@ -4,6 +4,7 @@ Backward compatibility module - imports all Wan nodes from their separate module
 
 from .generators.t2i import WanT2IGenerator
 from .generators.i2v import WanI2VGenerator
+from .generators.i2v_effect import WanI2VEffectGenerator
 from .generators.t2v import WanT2VGenerator
 from .generators.ii2v import WanII2VGenerator
 from .vace.image_reference import WanVACEImageReference
@@ -12,6 +13,6 @@ from .vace.video_edit import WanVACEVideoEdit
 from .vace.video_extension import WanVACEVideoExtension
 from .vace.video_outpainting import WanVACEVideoOutpainting
 
-__all__ = ['WanT2IGenerator', 'WanI2VGenerator', 'WanT2VGenerator', 'WanII2VGenerator', 
+__all__ = ['WanT2IGenerator', 'WanI2VGenerator', 'WanI2VEffectGenerator', 'WanT2VGenerator', 'WanII2VGenerator', 
            'WanVACEImageReference', 'WanVACEVideoRepainting', 'WanVACEVideoEdit', 
            'WanVACEVideoExtension', 'WanVACEVideoOutpainting']


### PR DESCRIPTION
Introduce WanI2VEffectGenerator to enhance the backward compatibility module, ensuring it is included in the public API.